### PR TITLE
Added dependency on pipeline-stage-view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -136,6 +136,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
             <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
+            <artifactId>pipeline-stage-view</artifactId>
+            <version>1.3</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
After merging I should be able to cut a 2.1 release and then publish the corresponding tag to the [Docker demo](https://hub.docker.com/r/jenkinsci/workflow-demo/), picking up #5.

@reviewbybees esp. @svanoort, and @kohsuke who has been asking for this for a while.