### PR TITLE
[JENKINS-39112] Move GitHubLibraryResolver to its own plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@
             <artifactId>pipeline-milestone-step</artifactId>
             <version>1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-github-lib</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
See [JENKINS-39112](https://issues.jenkins-ci.org/browse/JENKINS-39112) Sibling to https://github.com/jenkinsci/github-organization-folder-plugin/pull/33

@reviewbybees