### PR TITLE
Fix makefile build/run under Mac

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,4 +1,4 @@
-TAG=$(shell date -I -u)
+TAG=$(shell date -u +"%Y-%m-%dT%H-%M-%S")
 IMAGE=jenkinsci/workflow-demo
 DOCKER_RUN=docker run --rm -p 127.0.0.1:2222:2222 -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:9418:9418 -ti
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,5 +1,7 @@
 TAG=$(shell date -u +"%Y-%m-%d")
 IMAGE=jenkinsci/workflow-demo
+# Below will fetch the name of the docker host, and do a lookup, allowing the script to run with local docker or docker-machine both
+DOCKER_IP=$(docker info | grep -E '^Name: ' | sed 's/Name: //g' | xargs nslookup | grep -E 'Address: ' | sed 's/Address: //g' | uniq)
 DOCKER_RUN=docker run --rm -p 2222:2222 -p 8080:8080 -p 8081:8081 -p 9418:9418 -ti
 
 copy-plugins:

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,4 +1,4 @@
-TAG=$(shell date -u +"%Y-%m-%dT%H-%M-%S")
+TAG=$(shell date -u +"%Y-%m-%d")
 IMAGE=jenkinsci/workflow-demo
 DOCKER_RUN=docker run --rm -p 2222:2222 -p 8080:8080 -p 8081:8081 -p 9418:9418 -ti
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,6 +1,6 @@
 TAG=$(shell date -u +"%Y-%m-%dT%H-%M-%S")
 IMAGE=jenkinsci/workflow-demo
-DOCKER_RUN=docker run --rm -p 127.0.0.1:2222:2222 -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:9418:9418 -ti
+DOCKER_RUN=docker run --rm -p 2222:2222 -p 8080:8080 -p 8081:8081 -p 9418:9418 -ti
 
 copy-plugins:
 	set -e; \


### PR DESCRIPTION
This is due to a subtle difference between the Linux and Mac 'date' command version which breaks the makefile.  This fixes it.

It also fixes explicitly setting an ip address that may not match for docker-machine hosts vs. native docker.

@reviewbybees esp @jglick 