### PR TITLE
Add Declarative to aggregator

### DIFF
--- a/demo/plugins.txt
+++ b/demo/plugins.txt
@@ -29,9 +29,9 @@ org.jenkins-ci.plugins:structs:1.5
 org.jenkins-ci.plugins.workflow:workflow-aggregator:2.4
 org.jenkins-ci.plugins.workflow:workflow-api:2.8
 org.jenkins-ci.plugins.workflow:workflow-basic-steps:2.3
-org.jenkins-ci.plugins.workflow:workflow-cps:2.23
+org.jenkins-ci.plugins.workflow:workflow-cps:2.24
 org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:2.5
-org.jenkins-ci.plugins.workflow:workflow-durable-task-step:2.7
+org.jenkins-ci.plugins.workflow:workflow-durable-task-step:2.8
 org.jenkins-ci.plugins.workflow:workflow-job:2.9
 org.jenkins-ci.plugins.workflow:workflow-multibranch:2.9.2
 org.jenkins-ci.plugins.workflow:workflow-scm-step:2.3

--- a/pom.xml
+++ b/pom.xml
@@ -154,11 +154,6 @@
             <version>1.3</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>pipeline-github-lib</artifactId>
-            <version>1.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
             <version>1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.7.1</jenkins.version>
+        <jenkins.version>2.7.3</jenkins.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-aggregator</artifactId>
-    <version>2.5-beta-1-SNAPSHOT</version>
+    <version>2.5-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin</url>
@@ -63,23 +63,23 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins.version>2.7.1</jenkins.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.3</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.5</version>
+            <version>2.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -90,22 +90,22 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.4</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.17</version>
+            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps-global-lib</artifactId>
-            <version>2.3</version>
+            <version>2.5</version>
             <exclusions>
                 <exclusion>
                   <groupId>org.apache.httpcomponents</groupId>
@@ -116,27 +116,27 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.6</version>
+            <version>2.9</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.10-beta-1</version>
+            <version>2.9.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
-            <version>2.2</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.1</version>
+            <version>2.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -146,17 +146,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
             <artifactId>pipeline-stage-view</artifactId>
-            <version>2.0</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-milestone-step</artifactId>
-            <version>1.0</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-github-lib</artifactId>
-            <version>1.0-beta-1</version>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>1.0</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Note that this is deliberately not using workflow-multibranch 2.10,
since that depends on branch-api 2.0.0 and that's a problematic
release.

Dependency versions bumped to match those in
pipeline-model-definition's 1.0 release, along with reasonable updates
of plugins that aren't Declarative dependencies. This does require
moving to core 2.7.1 as well.

cc @reviewbybees esp @jglick 