### PR TITLE
[JENKINS-41558] Remove pipeline-stage-view

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,11 +149,6 @@
             <version>2.2</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
-            <artifactId>pipeline-stage-view</artifactId>
-            <version>2.4</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-milestone-step</artifactId>
             <version>1.3</version>


### PR DESCRIPTION
[JENKINS-41558](https://issues.jenkins-ci.org/browse/JENKINS-41558) looks like a severe bug, open for 8 months without any progress or response, despite many votes and watchers.

Since this plugin seems quite optional for pipeline use, it seems easiest to just remove it from the aggregator to prevent future new installs of Jenkins (setup wizard) from getting it by default.

Batteries included? Your batteries are leaking.

@abayer @jglick @svanoort 
@rtyler 