### PR TITLE
Upgrade all plugins to their latest dependencies present in the Update Center

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,13 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   ~ THE SOFTWARE.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>2.31</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-aggregator</artifactId>
@@ -69,37 +68,37 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.7</version>
+            <version>2.16</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.8</version>
+            <version>2.29</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.12</version>
+            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
+            <version>2.22</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>org.6wind.jenkins</groupId>
             <artifactId>lockable-resources</artifactId>
-            <version>2.0</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.24</version>
+            <version>2.56</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -110,7 +109,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps-global-lib</artifactId>
-            <version>2.5</version>
+            <version>2.11</version>
             <exclusions>
                 <exclusion>
                   <groupId>org.apache.httpcomponents</groupId>
@@ -121,47 +120,47 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
+            <version>2.25</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <version>2.11</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-multibranch</artifactId>
-            <version>2.9.2</version>
+            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-input-step</artifactId>
-            <version>2.5</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
             <artifactId>pipeline-stage-view</artifactId>
-            <version>2.4</version>
+            <version>2.10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-milestone-step</artifactId>
-            <version>1.3</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>pipeline-model-definition</artifactId>
-            <version>1.0</version>
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>
@@ -172,13 +171,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.28</version>
+            <version>1.46</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.13</version>
+            <version>1.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This brings the aggregator plugin up to date with the reality of what many
Jenkins users should be seeing right now

(this was scripted with my new `[check-updates](https://gist.github.com/rtyler/32e201037b6012779bb9727578255204)` script)

Closes #24 