### PR TITLE
Add pipeline-utility-steps to the suite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.21</version>
+        <version>3.32</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -74,12 +74,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.29</version>
+            <version>2.30</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.20</version>
+            <version>3.0</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.56</version>
+            <version>2.58</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.jenkins-ci.plugins</groupId>
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.15</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -197,6 +197,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
             <version>2.8.11.3</version>
+        </dependency>
+        <dependency>
+            <!-- RequireUpperBoundDeps -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.ui</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-utility-steps</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
             <version>1.15</version>
         </dependency>


### PR DESCRIPTION
I think it would make a lot of sense to have `pipeline-utility-steps` included by default, since it provides a nice set of additional steps and hence better OOTB UX for using Pipeline.

If there are legitimate reasons to not include it, at least this PR will serve the goal to discuss/list them anyway :-).

Thanks!

@rsandell @abayer @svanoort @jglick 