### PR TITLE
Fixed potential race condition in Jenkinsfile

### DIFF
--- a/demo/repo/Jenkinsfile
+++ b/demo/repo/Jenkinsfile
@@ -32,9 +32,10 @@ stage('Staging') {
     }
 }
 
-milestone 3
 stage ('Production') {
     lock(resource: 'production-server', inversePrecedence: true) {
+        milestone 3
+        
         node {
             sh "wget -O - -S ${jettyUrl}staging/"
             echo 'Production server looks to be alive'


### PR DESCRIPTION
Putting the third milestone outside of the lock, can potentially cause a racing condition leading to an old build being deployed to production. Here is how that can happen when milestone 3 stays outside of the lock:

Three builds are started: Build A, Build B and Build C.

Build A reaches the milestone first, no other build is currently running so it'll get the "production-server" lock.
Build B reaches the milestone second, and proceeds to wait for the "production-server" lock, still blocked by Build A.
Build C then also reaches the milestone and proceeds (as everything is in order), now also waiting for the "production-server" lock, still beeing blocked by Build A.
Now Build A finishes deploying to the production server and releases the "production-server" lock. Due to the "inversePrecedence" attribute, now Build C will get the lock first and proceed to deploy to the production server.
As soon as Build C finishes the deployment, Build B will get the lock and proceed to deploy an older version (Version B) to the production server.

This can be fixed by moving the third milestone inside of the lock, similar to milestone 2.