### PR TITLE
Add note to README indicating that plugins should not depend on workflow-aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- For newer versions, see [GitHub Releases](https://github.com/jenkinsci/workflow-aggregator-plugin/releases)
+
 ## 2.6 (Oct 3, 2018)
 
 -   Updated dependencies.

--- a/README.md
+++ b/README.md
@@ -26,5 +26,13 @@ GitHub](https://github.com/jenkinsci/pipeline-plugin). Quick links:
 Formerly known as the Workflow plugin. Originally inspired by the discontinued [Build
 Flow Plugin](https://github.com/jenkinsci/build-flow-plugin).
 
+## Developer Notes
+
+Plugins that implement Pipeline steps or integrate with Pipeline-related APIs **should not depend on `workflow-aggregator`** because it includes many unncessary dependencies.
+Instead, they should depend only on the plugins that provide the APIs necessary for the integration.
+For the common case of implementing a Pipeline step, plugins typically only need to depend on [`workflow-step-api`](https://plugins.jenkins.io/workflow-step-api/).
+In order to test Pipeline-related functionality, plugins need `test`-scope dependencies on [`workflow-job`](https://plugins.jenkins.io/workflow-job/) and [`workflow-cps`](https://plugins.jenkins.io/workflow-cps/).
+Additional `test`-scope dependencies on plugins like [`workflow-durable-task-step`](https://plugins.jenkins.io/workflow-durable-task-step) may be needed for more complex tests.
+
 ## Version History
 Please refer to [the changelog](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plugins that implement Pipeline steps or integrate with Pipeline-related APIs **
 Instead, they should depend only on the plugins that provide the APIs necessary for the integration.
 For the common case of implementing a Pipeline step, plugins typically only need to depend on [`workflow-step-api`](https://plugins.jenkins.io/workflow-step-api/).
 In order to test Pipeline-related functionality, plugins need `test`-scope dependencies on [`workflow-job`](https://plugins.jenkins.io/workflow-job/) and [`workflow-cps`](https://plugins.jenkins.io/workflow-cps/).
-Additional `test`-scope dependencies on plugins like [`workflow-durable-task-step`](https://plugins.jenkins.io/workflow-durable-task-step) may be needed for more complex tests.
+Additional `test`-scope dependencies on plugins like [`workflow-durable-task-step`](https://plugins.jenkins.io/workflow-durable-task-step) or [`workflow-basic-steps`](https://plugins.jenkins.io/workflow-basic-steps) may be needed for more complex tests.
 
 ## Version History
 Please refer to [the changelog](CHANGELOG.md).


### PR DESCRIPTION
`workflow-aggregator` only exists to make it easier for users to install the various plugins that make up Jenkins Pipeline and related features. It should never be used as a dependency of another plugin.

I thought we already had documentation about this, but I could not find anything, so this PR adds a quick note to the README, which would also show up on plugins.jenkins.io.