### PR TITLE
remove lockable-resources dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,6 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.6wind.jenkins</groupId>
-            <artifactId>lockable-resources</artifactId>
-            <version>2.3</version>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>2.56</version>


### PR DESCRIPTION
most people do not need the concurrency limits and whislt lockable resources is one way to acheive it, it does not need to be installed out of the box.

Removing from the aggregator, people that need it can choose to install it if they desire.

in essence reverts  #14

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
