### PR TITLE
Pick up `pipeline-groovy-lib` from BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.303.x</artifactId>
-                <version>1382.v7d694476f340</version>
+                <version>1409.v7659b_c072f18</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>pipeline-groovy-lib</artifactId>
-            <version>589.vb_a_b_4a_a_8c443c</version> <!-- TODO pending inclusion in BOM -->
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Cleanup from #52. Supersedes #53 & #54.